### PR TITLE
Add discovery functionality

### DIFF
--- a/chaosprometheus/__init__.py
+++ b/chaosprometheus/__init__.py
@@ -1,2 +1,35 @@
 # -*- coding: utf-8 -*-
+from typing import List
+
+from chaoslib.discovery.discover import (discover_actions, discover_probes,
+                                         initialize_discovery_result)
+from chaoslib.types import DiscoveredActivities, Discovery
+from logzero import logger
+
 __version__ = '0.3.0'
+
+
+def discover(discover_system: bool = True) -> Discovery:
+    """
+    Discover Prometheus capabilities from this extension.
+    """
+    logger.info("Discovering capabilities from chaostoolkit-prometheus")
+
+    discovery = initialize_discovery_result(
+        "chaostoolkit-prometheus", __version__, "prometheus")
+    discovery["activities"].extend(load_exported_activities())
+
+    return discovery
+
+
+###############################################################################
+# Private functions
+###############################################################################
+def load_exported_activities() -> List[DiscoveredActivities]:
+    """
+    Extract metadata from actions and probes exposed by this extension.
+    """
+    activities = []
+    activities.extend(discover_probes("chaosprometheus.probes"))
+
+    return activities


### PR DESCRIPTION
Add discovery functionality. I installed this branch in another project with pip and got the following results when running `chaos discover chaostoolkit-prometheus`:

```
$ chaos discover chaostoolkit-prometheus
[2019-07-21 12:38:16 INFO] Attempting to download and install package 'chaostoolkit-prometheus'
[2019-07-21 12:38:17 INFO] Package downloaded and installed in current environment
[2019-07-21 12:38:17 INFO] Discovering capabilities from chaostoolkit-prometheus
[2019-07-21 12:38:17 INFO] Searching for probes
[2019-07-21 12:38:17 INFO] Discovery outcome saved in ./discovery.json
```

Closes #6 

Signed-off-by: Simon Lindroos <simj91@gmail.com>