### PR TITLE
Fix broken tests when using chaostoolkit-lib==1.5.0

### DIFF
--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -10,21 +10,21 @@ from chaosprometheus.probes import query, query_interval
 def test_failed_parsing_when_date():
     with pytest.raises(FailedActivity) as exc:
         query("request_processing_seconds_count", when="2 mns ago")
-    assert "failed to parse '2 mns ago'" in str(exc)
+    assert "failed to parse '2 mns ago'" in str(exc.value)
 
 
 def test_failed_parsing_start_date():
     with pytest.raises(FailedActivity) as exc:
         query_interval("request_processing_seconds_count", start="2 mns ago",
                        end="now")
-    assert "failed to parse '2 mns ago'" in str(exc)
+    assert "failed to parse '2 mns ago'" in str(exc.value)
 
 
 def test_failed_parsing_end_date():
     with pytest.raises(FailedActivity) as exc:
         query_interval("request_processing_seconds_count",
                        start="2 minutes ago", end="right now")
-    assert "failed to parse 'right now'" in str(exc)
+    assert "failed to parse 'right now'" in str(exc.value)
 
 
 def test_failed_running_query():
@@ -36,4 +36,4 @@ def test_failed_running_query():
         with pytest.raises(FailedActivity) as ex:
             query_interval(query="request_processing_seconds_count",
                            start="2 minutes ago", end="now")
-    assert "Prometheus query" in str(ex)
+    assert "Prometheus query" in str(ex.value)


### PR DESCRIPTION
Tests were failing on master because (I am guessing) a change made to how exceptions are represented as strings in the chaostoolkit-lib module.

Signed-off-by: Simon Lindroos <simj91@gmail.com>