### PR TITLE
Prometheus (range_)query steady-state tolerance verification probes

### DIFF
--- a/chaosprometheus/__init__.py
+++ b/chaosprometheus/__init__.py
@@ -6,7 +6,7 @@ from chaoslib.discovery.discover import (discover_actions, discover_probes,
 from chaoslib.types import DiscoveredActivities, Discovery
 from logzero import logger
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 def discover(discover_system: bool = True) -> Discovery:

--- a/chaosprometheus/__init__.py
+++ b/chaosprometheus/__init__.py
@@ -31,5 +31,6 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     """
     activities = []
     activities.extend(discover_probes("chaosprometheus.probes"))
+    activities.extend(discover_probes("chaosprometheus.verification.probes"))
 
     return activities

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -30,8 +30,9 @@ def query_results_lower_than_threshold(value: dict,
                                              threshold_varible)),
                                              threshold_variable_prefix,
                                              threshold_variable))
-            threshold = float(os.getenv("%s-%s") % (threshold_variable_prefix,
-                                                    threshold_variable))
+            threshold = __parse_to_number(os.getenv("%s-%s") %
+                                          (threshold_variable_prefix,
+                                           threshold_variable))
 
     if threshold is None:
         raise Exception("No threshold given")
@@ -55,23 +56,25 @@ def query_results_lower_than_threshold(value: dict,
     if range_query:
         for entry in value['data']['result']:
             for value in entry['values']:
-                if value[1] < threshold:
+                v = __parse_to_number(value[1])
+                if v < threshold:
                     logger.debug("Probe: value %f is below the threshold %f"
-                                 % (value[1], threshold))
+                                 % (v, threshold))
                 else:
                     logger.error("Probe: value %f is higher than threshold %f"
-                                 % (value[1], threshold))
+                                 % (v, threshold))
                     rtn = False
 
     # handle Prometheus query
     else:
         for entry in value['data']['result']:
-            if entry['value'][1] < threshold:
+            v = __parse_to_number(entry['value'][1])
+            if v < threshold:
                 logger.debug("Probe: value %f is below the threshold %f" %
-                             (entry['value'][1], threshold))
+                             (v, threshold))
             else:
                 logger.error("Probe: value %f is higher than threshold %f" %
-                             (entry['value'][1], threshold))
+                             (v, threshold))
                 rtn = False
 
     if rtn:
@@ -102,8 +105,9 @@ def query_results_higher_than_threshold(value: dict,
                                              threshold_varible)),
                                              threshold_variable_prefix,
                                              threshold_variable))
-            threshold = float(os.getenv("%s-%s") % (threshold_variable_prefix,
-                                                    threshold_variable))
+            threshold = __parse_to_number(os.getenv("%s-%s") %
+                                          (threshold_variable_prefix,
+                                           threshold_variable))
 
     if threshold is None:
         raise Exception("No threshold given")
@@ -127,23 +131,25 @@ def query_results_higher_than_threshold(value: dict,
     if range_query:
         for entry in value['data']['result']:
             for value in entry['values']:
-                if value[1] > threshold:
+                v = __parse_to_number(value[1])
+                if v > threshold:
                     logger.debug("Probe: value %f is higher than threshold %f"
-                                 % (value[1], threshold))
+                                 % (v, threshold))
                 else:
                     logger.error("Probe: value %f is below the threshold %f"
-                                 % (value[1], threshold))
+                                 % (v, threshold))
                     rtn = False
 
     # handle Prometheus query
     else:
         for entry in value['data']['result']:
-            if entry['value'][1] > threshold:
+            v = __parse_to_number(entry['value'][1])
+            if v > threshold:
                 logger.debug("Probe: value %f is higher than threshold %f" %
-                             (entry['value'][1], threshold))
+                             (v, threshold))
             else:
                 logger.error("Probe: value %f is below the threshold %f" %
-                             (entry['value'][1], threshold))
+                             (v, threshold))
                 rtn = False
 
     if rtn:
@@ -194,7 +200,7 @@ def set_result_as_threshold_variable(value: dict,
             for metric in value['data']['result']:
                 threshold = float(0.0)
                 for value in metric['values']:
-                    threshold += float(value[1])
+                    threshold += __parse_to_number(value[1])
                 metrics_thresholds.append(
                     float(threshold / len(metric['values'])))
             threshold = float(0.0)
@@ -210,7 +216,7 @@ def set_result_as_threshold_variable(value: dict,
     else:
         try:
             for metric in value['data']['result']:
-                threshold += float(metric['value'][1])
+                threshold += __parse_to_number(metric['value'][1])
             threshold /= len(value['data']['result'])
         except Exception as e:
             logger.error("Probe: An error occured during the threshold\
@@ -226,3 +232,14 @@ def set_result_as_threshold_variable(value: dict,
                 (threshold, threshold_variable))
 
     return True
+
+
+def __parse_to_number(s: str):
+    """
+    Parses given string `s` either into an int or float.
+    If it can't parse it, it throws an exception.
+    """
+    try:
+        return int(s)
+    except ValueError:
+        return float(s)

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -49,14 +49,10 @@ def query_results_lower_than_threshold(value: dict,
     if threshold_variable:
         if ("%s-%s" % (threshold_variable_prefix, threshold_variable))\
           in globals():
-            logger.debug("Probe: Using threshold %s from global\
-                          variable %s-%s" % (globals()["%s-%s" % (
-                                             threshold_variable_prefix,
-                                             threshold_variable)],
-                                             threshold_variable_prefix,
-                                             threshold_variable))
             threshold = globals()[("%s-%s") % (threshold_variable_prefix,
                                                threshold_variable)]
+            logger.debug("Probe: Using threshold %f from global\
+variable %s-%s" % (threshold, threshold_variable_prefix, threshold_variable))
 
     if threshold is None:
         raise Exception("No threshold given")
@@ -123,14 +119,10 @@ def query_results_higher_than_threshold(value: dict,
     if threshold_variable:
         if "%s-%s" % (threshold_variable_prefix, threshold_variable)\
           in globals():
-            logger.debug("Probe: Using threshold %s from global\
-                          variable %s-%s" % (globals()["%s-%s" % (
-                                             threshold_variable_prefix,
-                                             threshold_variable)],
-                                             threshold_variable_prefix,
-                                             threshold_variable))
             threshold = globals()[("%s-%s") % (threshold_variable_prefix,
                                                threshold_variable)]
+            logger.debug("Probe: Using threshold %f from global\
+variable %s-%s" % (threshold, threshold_variable_prefix, threshold_variable))
 
     if threshold is None:
         raise Exception("No threshold given")

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from logzero import logger
+
+__all__ = ["query_results_lower_than_threshold"]
+
+
+def query_results_lower_than_threshold(threshold: int,
+                                       value: dict) -> bool:
+    """
+    Checks if all passed Prometheus values are below the
+    given threshold. If so returns True, otherwise False.
+    If no threshold is given it throws an exception.
+    """
+    if threshold is None:
+        raise Exception("No threshold given")
+    logger.info("threshold: %d" % (threshold,))
+    print(value)
+    return True

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -52,7 +52,7 @@ def query_results_lower_than_threshold(value: dict,
             logger.debug("Probe: Using threshold %s from global\
                           variable %s-%s" % (globals()["%s-%s" % (
                                              threshold_variable_prefix,
-                                             threshold_varible)],
+                                             threshold_variable)],
                                              threshold_variable_prefix,
                                              threshold_variable))
             threshold = globals()[("%s-%s") % (threshold_variable_prefix,
@@ -126,7 +126,7 @@ def query_results_higher_than_threshold(value: dict,
             logger.debug("Probe: Using threshold %s from global\
                           variable %s-%s" % (globals()["%s-%s" % (
                                              threshold_variable_prefix,
-                                             threshold_varible)],
+                                             threshold_variable)],
                                              threshold_variable_prefix,
                                              threshold_variable))
             threshold = globals()[("%s-%s") % (threshold_variable_prefix,

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -1,39 +1,225 @@
 # -*- coding: utf-8 -*-
 from logzero import logger
+import os
 
-__all__ = ["query_results_lower_than_threshold"]
+__all__ = ["query_results_lower_than_threshold",
+           "query_results_higher_than_threshold",
+           "set_result_as_threshold"]
+
+threshold_variable_prefix = "chaosprometheus"
 
 
-def query_results_lower_than_threshold(threshold: int,
+def query_results_lower_than_threshold(threshold: float = None,
+                                       threshold_variable: str = None,
                                        value: dict) -> bool:
     """
     Checks if all passed Prometheus values are below the
     given threshold. If so returns True, otherwise False.
     If no threshold is given it throws an exception.
+    This function can also verify against a saved `threshold_variable`.
+    Values from a `threshold_variable` take precedence over `threshold`
+    values.
     """
-    rtn = True
+    if threshold_variable:
+        if os.getenv("%s-%s" % (threshold_variable_prefix,
+                                threshold_variable)):
+            logger.debug("Probe: Using threshold %s from environment\
+                          variable %s-%s" % (os.getenv("%s-%s" % (
+                                             threshold_variable_prefix,
+                                             threshold_varible)),
+                                             threshold_variable_prefix,
+                                             threshold_variable))
+            threshold = float(os.getenv("%s-%s") % (threshold_variable_prefix,
+                                                    threshold_variable))
+
     if threshold is None:
         raise Exception("No threshold given")
 
-    logger.debug(str(value))
+    rtn = True
 
-    # check if we got none, a result (query) or multiple results (range_query)
-    # from Prometheus. If no results are provided, throw a warning and return
-    # with True / ok
+    # if no query result is provided exit with False
+    if len(value['data']['result']) == 0:
+        logger.error("Probe: The query didn't provide any result")
+        return False
+
+    # check if we got results from a range_query
+    range_query = False
+    try:
+        tmp = value['data']['result'][0]['values']
+        range_query = True
+    except Exception:
+        pass
 
     # handle Prometheus range_query
+    if range_query:
+        for entry in value['data']['result']:
+            for value in entry['values']:
+                if value[1] < threshold:
+                    logger.debug("Probe: value %f is below the threshold %f"
+                                 % (value[1], threshold))
+                else:
+                    logger.error("Probe: value %f is higher than threshold %f"
+                                 % (value[1], threshold))
+                    rtn = False
 
     # handle Prometheus query
-    for entry in value.data.result:
-        if entry.value[1] < threshold:
-            logger.debug("Probe: value %f is below threshold %d" %
-                         (entry.value[1], threshold))
-        else:
-            logger.error("Probe: value %f is higher than threshold %d" %
-                         (entry.value[1], threshold))
-            rtn = False
+    else:
+        for entry in value['data']['result']:
+            if entry['value'][1] < threshold:
+                logger.debug("Probe: value %f is below the threshold %f" %
+                             (entry.['value'][1], threshold))
+            else:
+                logger.error("Probe: value %f is higher than threshold %f" %
+                             (entry.['value'][1], threshold))
+                rtn = False
 
     if rtn:
-        logger.info("Probe: ok, all values are below the given threshold")
+        logger.info("Probe: ok, all values are below the given threshold\
+                     of %f" % (threshold,))
 
     return rtn
+
+
+def query_results_higher_than_threshold(threshold: float = None,
+                                        threshold_variable: str = None,
+                                        value: dict) -> bool:
+    """
+    Checks if all passed Prometheus values are higher than the
+    given threshold. If so returns True, otherwise False.
+    If no threshold is given it throws an exception.
+    This function can also verify against a saved `threshold_variable`.
+    Values from a `threshold_variable` take precedence over `threshold`
+    values.
+    """
+    if threshold_variable:
+        if os.getenv("%s-%s" % (threshold_variable_prefix,
+                                threshold_variable)):
+            logger.debug("Probe: Using threshold %s from environment\
+                          variable %s-%s" % (os.getenv("%s-%s" % (
+                                             threshold_variable_prefix,
+                                             threshold_varible)),
+                                             threshold_variable_prefix,
+                                             threshold_variable))
+            threshold = float(os.getenv("%s-%s") % (threshold_variable_prefix,
+                                                    threshold_variable))
+
+    if threshold is None:
+        raise Exception("No threshold given")
+
+    rtn = True
+
+    # if no query result is provided exit with False
+    if len(value['data']['result']) == 0:
+        logger.error("Probe: The query didn't provide any result")
+        return False
+
+    # check if we got results from a range_query
+    range_query = False
+    try:
+        tmp = value['data']['result'][0]['values']
+        range_query = True
+    except Exception:
+        pass
+
+    # handle Prometheus range_query
+    if range_query:
+        for entry in value['data']['result']:
+            for value in entry['values']:
+                if value[1] > threshold:
+                    logger.debug("Probe: value %f is higher than threshold %f"
+                                 % (value[1], threshold))
+                else:
+                    logger.error("Probe: value %f is below the threshold %f"
+                                 % (value[1], threshold))
+                    rtn = False
+
+    # handle Prometheus query
+    else:
+        for entry in value['data']['result']:
+            if entry['value'][1] > threshold:
+                logger.debug("Probe: value %f is higher than threshold %f" %
+                             (entry.['value'][1], threshold))
+            else:
+                logger.error("Probe: value %f is below the threshold %f" %
+                             (entry.['value'][1], threshold))
+                rtn = False
+
+    if rtn:
+        logger.info("Probe: ok, all values are higher than the given\
+                     threshold %f" % (threshold,))
+
+    return rtn
+
+
+def set_result_as_threshold_variable(threshold_variable: str,
+                                     resize: int = 100,
+                                     value: dict) -> bool:
+    """
+    Saves the passed Prometheus query value in an environment
+    `threshold_variable` that can be used by query_results_
+    functions. Allows to adapt the threshold_variable in % of its own value
+    through the `resize` parameter to reduce or increase the threshold value.
+
+    If a `value` is provided from a Prometheus range_query, the average of
+    all values will be used as referrence.
+
+    If more than one metric is provided, the average of all metrics will be
+    averaged and used as referrence.
+
+    Returns True if it succeeds saving the value in the `threshold_variable`.
+    Otherwise, returns False or throws an exception.
+    """
+    # if no query result is provided exit with False
+    if len(value['data']['result']) == 0:
+        logger.error("Probe: The query didn't provide any result")
+        return False
+
+    # check if we got results from a range_query
+    range_query = False
+    try:
+        tmp = value['data']['result'][0]['values']
+        range_query = True
+    except Exception:
+        pass
+
+    threshold = float(0.0)
+
+    # extract the average threshold from the Prometheus range_query
+    if range_query:
+        metrics_thresholds = []
+        try:
+            for metric in value['data']['result']:
+                threshold = float(0.0)
+                for value in metric['values']:
+                    threshold += float(value[1])
+                metrics_thresholds.append(
+                    float(threshold / len(metric['values'])))
+            threshold = float(0.0)
+            for t in metrics_threshold:
+                threshold += t
+            threshold /= len(metrics_threshold)
+        except Exception as e:
+            logger.error("Probe: An error occured during the threshold\
+                          calculation. %s" % (e,))
+            return False
+
+    # extract the average threshold value from the Prometheus query
+    else:
+        try:
+            for metric in value['data']['result']:
+                threshold += float(metric['value'][1])
+            threshold /= len(value['data']['result'])
+        except Exception as e:
+            logger.error("Probe: An error occured during the threshold\
+                          calculation. %s" % (e,))
+            return False
+
+    # resize the threshold and save it in an environment variable
+    threshold = threshold * float(resize/100)
+    os.environ["%s-%s" % (threshold_variable_prefix, threshold_variable)] = \
+        str(threshold)
+
+    logger.info("Probe: saved threshold %f in threshold_variable %s" %
+                (threshold, threshold_variable))
+
+    return True

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -9,9 +9,10 @@ __all__ = ["query_results_lower_than_threshold",
 threshold_variable_prefix = "chaosprometheus"
 
 
-def query_results_lower_than_threshold(threshold: float = None,
+def query_results_lower_than_threshold(value: dict,
+                                       threshold: float = None,
                                        threshold_variable: str = None,
-                                       value: dict) -> bool:
+                                       ) -> bool:
     """
     Checks if all passed Prometheus values are below the
     given threshold. If so returns True, otherwise False.
@@ -80,9 +81,10 @@ def query_results_lower_than_threshold(threshold: float = None,
     return rtn
 
 
-def query_results_higher_than_threshold(threshold: float = None,
+def query_results_higher_than_threshold(value: dict,
+                                        threshold: float = None,
                                         threshold_variable: str = None,
-                                        value: dict) -> bool:
+                                        ) -> bool:
     """
     Checks if all passed Prometheus values are higher than the
     given threshold. If so returns True, otherwise False.
@@ -151,9 +153,10 @@ def query_results_higher_than_threshold(threshold: float = None,
     return rtn
 
 
-def set_result_as_threshold_variable(threshold_variable: str,
+def set_result_as_threshold_variable(value: dict,
+                                     threshold_variable: str,
                                      resize: int = 100,
-                                     value: dict) -> bool:
+                                     ) -> bool:
     """
     Saves the passed Prometheus query value in an environment
     `threshold_variable` that can be used by query_results_

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from logzero import logger
+from chaoslib.exceptions import ActivityFailed
 import os
 
 __all__ = ["query_results_lower_than_threshold",
@@ -55,14 +56,15 @@ def query_results_lower_than_threshold(value: dict,
 variable %s-%s" % (threshold, threshold_variable_prefix, threshold_variable))
 
     if threshold is None:
-        raise Exception("No threshold given")
+        logger.error("Probe: No threshold given")
+        raise ActivityFailed()
 
     rtn = True
 
     # if no query result is provided exit with False
     if len(value['data']['result']) == 0:
         logger.error("Probe: The query didn't provide any result")
-        return False
+        raise ActivityFailed()
 
     # check if we got results from a range_query
     range_query = False
@@ -100,6 +102,8 @@ variable %s-%s" % (threshold, threshold_variable_prefix, threshold_variable))
     if rtn:
         logger.info("Probe: ok, all values are below the given threshold\
  of %f" % (threshold,))
+    else:
+        raise ActivityFailed()
 
     return rtn
 
@@ -125,14 +129,15 @@ def query_results_higher_than_threshold(value: dict,
 variable %s-%s" % (threshold, threshold_variable_prefix, threshold_variable))
 
     if threshold is None:
-        raise Exception("No threshold given")
+        logger.error("Probe: No threshold given")
+        raise ActivityFailed()
 
     rtn = True
 
     # if no query result is provided exit with False
     if len(value['data']['result']) == 0:
         logger.error("Probe: The query didn't provide any result")
-        return False
+        raise ActivityFailed()
 
     # check if we got results from a range_query
     range_query = False
@@ -170,6 +175,8 @@ variable %s-%s" % (threshold, threshold_variable_prefix, threshold_variable))
     if rtn:
         logger.info("Probe: ok, all values are higher than the given\
  threshold %f" % (threshold,))
+    else:
+        raise ActivityFailed()
 
     return rtn
 
@@ -196,7 +203,7 @@ def __set_result_as_threshold_variable(value: dict,
     # if no query result is provided exit with False
     if len(value['data']['result']) == 0:
         logger.error("Probe: The query didn't provide any result")
-        return False
+        raise ActivityFailed()
 
     # check if we got results from a range_query
     range_query = False
@@ -225,7 +232,7 @@ def __set_result_as_threshold_variable(value: dict,
         except Exception as e:
             logger.error("Probe: An error occured during the threshold\
  calculation. %s" % (e,))
-            return False
+            raise ActivityFailed(e)
 
     # extract the average threshold value from the Prometheus query
     else:
@@ -236,7 +243,7 @@ def __set_result_as_threshold_variable(value: dict,
         except Exception as e:
             logger.error("Probe: An error occured during the threshold\
  calculation. %s" % (e,))
-            return False
+            raise ActivityFailed(e)
 
     # resize the threshold and save it in an environment variable
     threshold = threshold * float(resize/100)

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -5,7 +5,7 @@ import os
 
 __all__ = ["query_results_lower_than_threshold",
            "query_results_higher_than_threshold",
-           "set_result_as_threshold"]
+           "query_result_degradation"]
 
 threshold_variable_prefix = "chaosprometheus"
 
@@ -18,6 +18,21 @@ def query_result_degradation(value: dict,
     On the first run, saves the average of the query result as reference.
     On the second run, compares the average query result against the reference
     to detect performance degradation.
+
+    The parameter `value` will be filled automatically by chaostoolkit and will
+    receive the result from Prometheus'es (range_)query.
+    The parameter `threshold_variable` defines in what variable the threshold
+    will be temporarily stored.
+    The parameter `resize` can be used to resize the threshold_variable's
+    value to define an upper or lower bound. The resize value defines the
+    percentage to which the actual threshold value will be resized. (e.g.
+    a value of 100 results in no change, a value 90 results in a decrease of
+    10%, and a value of 110 results in an increase of 10% of the original
+    threshold value.)
+    If the parameter `higher` is set to `True` the observed value of the 2nd
+    run needs to be higher than the reference value. If the parameter `higher`
+    is set to `False` the observed value of the 2nd run needs to be below the
+    reference value of the 1st run.
     """
     # second run (compare reference and new value)
     if "%s-%s" % (threshold_variable_prefix, threshold_variable) in globals():

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -67,10 +67,10 @@ def query_results_lower_than_threshold(threshold: float = None,
         for entry in value['data']['result']:
             if entry['value'][1] < threshold:
                 logger.debug("Probe: value %f is below the threshold %f" %
-                             (entry.['value'][1], threshold))
+                             (entry['value'][1], threshold))
             else:
                 logger.error("Probe: value %f is higher than threshold %f" %
-                             (entry.['value'][1], threshold))
+                             (entry['value'][1], threshold))
                 rtn = False
 
     if rtn:
@@ -138,10 +138,10 @@ def query_results_higher_than_threshold(threshold: float = None,
         for entry in value['data']['result']:
             if entry['value'][1] > threshold:
                 logger.debug("Probe: value %f is higher than threshold %f" %
-                             (entry.['value'][1], threshold))
+                             (entry['value'][1], threshold))
             else:
                 logger.error("Probe: value %f is below the threshold %f" %
-                             (entry.['value'][1], threshold))
+                             (entry['value'][1], threshold))
                 rtn = False
 
     if rtn:

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -11,8 +11,29 @@ def query_results_lower_than_threshold(threshold: int,
     given threshold. If so returns True, otherwise False.
     If no threshold is given it throws an exception.
     """
+    rtn = True
     if threshold is None:
         raise Exception("No threshold given")
-    logger.info("threshold: %d" % (threshold,))
-    print(value)
-    return True
+
+    logger.debug(str(value))
+
+    # check if we got none, a result (query) or multiple results (range_query)
+    # from Prometheus. If no results are provided, throw a warning and return
+    # with True / ok
+
+    # handle Prometheus range_query
+
+    # handle Prometheus query
+    for entry in value.data.result:
+        if entry.value[1] < threshold:
+            logger.debug("Probe: value %f is below threshold %d" %
+                         (entry.value[1], threshold))
+        else:
+            logger.error("Probe: value %f is higher than threshold %d" %
+                         (entry.value[1], threshold))
+            rtn = False
+
+    if rtn:
+        logger.info("Probe: ok, all values are below the given threshold")
+
+    return rtn

--- a/chaosprometheus/verification/probes.py
+++ b/chaosprometheus/verification/probes.py
@@ -47,8 +47,8 @@ def query_results_lower_than_threshold(value: dict,
     values.
     """
     if threshold_variable:
-        if ("%s-%s" % (threshold_variable_prefix, threshold_variable))
-        in globals:
+        if ("%s-%s" % (threshold_variable_prefix, threshold_variable))\
+          in globals():
             logger.debug("Probe: Using threshold %s from global\
                           variable %s-%s" % (globals()["%s-%s" % (
                                              threshold_variable_prefix,
@@ -121,8 +121,8 @@ def query_results_higher_than_threshold(value: dict,
     values.
     """
     if threshold_variable:
-        if ("%s-%s" % (threshold_variable_prefix, threshold_variable))
-        in globals:
+        if "%s-%s" % (threshold_variable_prefix, threshold_variable)\
+          in globals():
             logger.debug("Probe: Using threshold %s from global\
                           variable %s-%s" % (globals()["%s-%s" % (
                                              threshold_variable_prefix,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ author_email = 'sh@defuze.org'
 url = 'http://chaostoolkit.org'
 license = 'Apache License Version 2.0'
 packages = [
-    'chaosprometheus'
+    'chaosprometheus',
+    'chaosprometheus.verification'
 ]
 
 needs_pytest = set(['pytest', 'test']).intersection(sys.argv)

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -3,9 +3,12 @@ import pytest
 import requests
 import requests_mock
 
-from chaoslib.exceptions import FailedActivity
+from chaoslib.exceptions import FailedActivity, ActivityFailed
 from chaosprometheus.probes import query, query_interval
-
+from chaosprometheus.verification.probes import\
+ query_results_lower_than_threshold,\
+ query_results_higher_than_threshold,\
+ query_result_degradation
 
 def test_failed_parsing_when_date():
     with pytest.raises(FailedActivity) as exc:
@@ -37,3 +40,121 @@ def test_failed_running_query():
             query_interval(query="request_processing_seconds_count",
                            start="2 minutes ago", end="now")
     assert "Prometheus query" in str(ex.value)
+
+
+###
+# chaosprometheus.verification tests
+###
+
+query_value = {"status":"success","data":{"resultType":"vector","result":[{
+        "metric":{"__name__":"total_transactions","instance":"10.0.0.1:9003",
+            "job":"kubernetes-pods", "kubernetes_pod_name":"benchmark"},
+        "value":[1565084302.6,"181383"]},
+        {"metric":{"__name__":"total_transactions","instance":"10.0.0.1:9003",
+        "job":"kubernetes-pods-to-be-scraped-more-frequently",
+        "kubernetes_pod_name":"benchmark"},
+        "value":[1565084302.6,"183631"]}]}}
+
+
+range_query_value = {"status":"success","data":{"resultType":"matrix",
+    "result":[{"metric":{"instance":"10.0.0.1:9003",
+     "job":"kubernetes-pods-to-be-scraped-more-frequently"
+     ,"kubernetes_pod_name":"benchmark"},
+     "values":[[1565083822.600,"105.5"],[1565083824.600,"101.5"],
+         [1565083826.600,"108.5"], [1565083828.600,"108.5"],
+         [1565083830.600,"116.5"],[1565083832.600,"113"],
+         [1565083834.600,"114"],[1565083836.600,"109.5"],
+         [1565083838.600,"112"],[1565083840.600,"117"],
+         [1565083842.600,"110.5"],[1565083844.600,"114"],
+         [1565083846.600,"115.5"],[1565083848.600,"114.5"],
+         [1565083850.600,"113"],[1565083858.600,"116"],
+         [1565083860.600,"118"],[1565083862.600,"108.5"]
+    ]}]}}
+
+
+def test_query_results_lower_than_threshold_success():
+    rtn = query_results_lower_than_threshold(query_value, threshold=184000)
+    assert rtn is True
+
+
+def test_query_results_lower_than_threshold_fail():
+    with pytest.raises(ActivityFailed):
+        rtn = query_results_lower_than_threshold(query_value,
+                                                 threshold=183630)
+
+
+def test_query_results_higher_than_threshold_success():
+    rtn = query_results_higher_than_threshold(query_value, threshold=181382)
+    assert rtn is True
+
+
+def test_query_results_higher_than_threshold_fail():
+    with pytest.raises(ActivityFailed):
+        rtn = query_results_higher_than_threshold(query_value,
+                                                  threshold=181384)
+
+
+def test_range_query_results_lower_than_threshold_success():
+    rtn = query_results_lower_than_threshold(range_query_value, threshold=120)
+    assert rtn is True
+
+
+def test_range_query_results_lower_than_threshold_fail():
+    with pytest.raises(ActivityFailed):
+        rtn = query_results_lower_than_threshold(range_query_value,
+                                                 threshold=109)
+
+
+def test_range_query_results_higher_than_threshold_success():
+    rtn = query_results_higher_than_threshold(range_query_value, threshold=100)
+    assert rtn is True
+
+
+def test_range_query_results_higher_than_threshold_fail():
+    with pytest.raises(ActivityFailed):
+        rtn = query_results_higher_than_threshold(range_query_value,
+                                                  threshold=109)
+
+
+def test_query_result_degradation_lower_success():
+    rtn = query_result_degradation(query_value,
+                                   threshold_variable="deg_low_succ",
+                                   resize=110, higher=False)
+    assert rtn is True
+    rtn = query_result_degradation(query_value,
+                                   threshold_variable="deg_low_succ",
+                                   resize=110, higher=False)
+    assert rtn is True
+
+
+def test_query_result_degradation_lower_fail():
+    rtn = query_result_degradation(query_value,
+                                   threshold_variable="deg_low_fail",
+                                   resize=90, higher=False)
+    assert rtn is True
+    with pytest.raises(ActivityFailed):
+        rtn = query_result_degradation(query_value,
+                                       threshold_variable="deg_low_fail",
+                                       resize=90, higher=False)
+
+
+def test_query_result_degradation_higher_success():
+    rtn = query_result_degradation(query_value,
+                                   threshold_variable="deg_hig_succ",
+                                   resize=90, higher=True)
+    assert rtn is True
+    rtn = query_result_degradation(query_value,
+                                   threshold_variable="deg_hig_succ",
+                                   resize=90, higher=True)
+    assert rtn is True
+
+
+def test_query_result_degradation_higher_fail():
+    rtn = query_result_degradation(query_value,
+                                   threshold_variable="deg_hig_fail",
+                                   resize=110, higher=True)
+    assert rtn is True
+    with pytest.raises(ActivityFailed):
+        rtn = query_result_degradation(query_value,
+                                       threshold_variable="deg_hig_fail",
+                                       resize=110, higher=True)


### PR DESCRIPTION
Added steady-state tolerance probes \[1\] to verify Prometheus (range_)query results against int or float thresholds.

- *query_results_lower_than_threshold* checks if the Prometheus results are below a given threshold
- *query_results_higher_than_threshold* checks if Prometheus results are higher than a given threshold
- *query_result_degradation* checks if the average Prometheus query results deviate between the first run of the steady-state-probe and the second run.

Also added test cases to verify the steady-state tolerance probes' functionality.

\[1\] https://docs.chaostoolkit.org/reference/tutorials/tolerance/#advanced-scenarios