### PR TITLE
Adding verify_tls parameter to disable ssl/tls verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-prometheus/compare/0.5.0...HEAD
 
+### Added
+
+- Option to disable endpoint TLS certificate verification 
+
 ## [0.5.0][] - 2022-12-23
 
 [0.5.0]: https://github.com/chaostoolkit/chaostoolkit-prometheus/compare/0.4.0...0.5.0

--- a/chaosprometheus/probes.py
+++ b/chaosprometheus/probes.py
@@ -23,6 +23,7 @@ def query(
     timeout: float = None,
     configuration: Configuration = None,
     secrets: Secrets = None,
+    verify_tls: bool = True,
 ) -> Dict[str, Any]:
     """
     Run an instant query against a Prometheus server and returns its result
@@ -48,7 +49,7 @@ def query(
 
     logger.debug("Querying with: {q}".format(q=params))
 
-    r = requests.get(url, headers={"Accept": "application/json"}, params=params)
+    r = requests.get(url, headers={"Accept": "application/json"}, params=params, verify=verify_tls)
 
     if r.status_code != 200:
         raise FailedActivity(
@@ -66,6 +67,7 @@ def query_interval(
     timeout: float = None,
     configuration: Configuration = None,
     secrets: Secrets = None,
+    verify_tls: bool = True,
 ) -> Dict[str, Any]:
     """
     Run a range query against a Prometheus server and returns its result as-is.
@@ -100,7 +102,7 @@ def query_interval(
 
     logger.debug("Querying with: {q}".format(q=params))
 
-    r = requests.get(url, headers={"Accept": "application/json"}, params=params)
+    r = requests.get(url, headers={"Accept": "application/json"}, params=params, verify=verify_tls)
 
     if r.status_code != 200:
         raise FailedActivity(

--- a/chaosprometheus/probes.py
+++ b/chaosprometheus/probes.py
@@ -21,9 +21,9 @@ def query(
     query: str,
     when: str = None,
     timeout: float = None,
+    verify_tls: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
-    verify_tls: bool = True,
 ) -> Dict[str, Any]:
     """
     Run an instant query against a Prometheus server and returns its result
@@ -49,7 +49,12 @@ def query(
 
     logger.debug("Querying with: {q}".format(q=params))
 
-    r = requests.get(url, headers={"Accept": "application/json"}, params=params, verify=verify_tls)
+    r = requests.get(
+        url, 
+        headers={"Accept": "application/json"}, 
+        params=params, 
+        verify=verify_tls
+    )
 
     if r.status_code != 200:
         raise FailedActivity(
@@ -65,9 +70,9 @@ def query_interval(
     end: str,
     step: int = 1,
     timeout: float = None,
+    verify_tls: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
-    verify_tls: bool = True,
 ) -> Dict[str, Any]:
     """
     Run a range query against a Prometheus server and returns its result as-is.
@@ -102,7 +107,12 @@ def query_interval(
 
     logger.debug("Querying with: {q}".format(q=params))
 
-    r = requests.get(url, headers={"Accept": "application/json"}, params=params, verify=verify_tls)
+    r = requests.get(
+        url, 
+        headers={"Accept": "application/json"}, 
+        params=params, 
+        verify=verify_tls
+    )
 
     if r.status_code != 200:
         raise FailedActivity(


### PR DESCRIPTION
Hello,

Adding the verify_tls parameter to give the possibility to query prometheus without checking it's certificate.